### PR TITLE
Update torchcodec to 0.3.0

### DIFF
--- a/.ci_support/linux_64_cuda_compiler_version12.6python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version12.6python3.10.____cpython.yaml
@@ -25,7 +25,7 @@ docker_image:
 ffmpeg:
 - '7'
 libtorch:
-- '2.6'
+- '2.7'
 magma:
 - '2.9'
 nccl:
@@ -37,7 +37,7 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 pytorch:
-- '2.6'
+- '2.7'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_cuda_compiler_version12.6python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version12.6python3.11.____cpython.yaml
@@ -25,7 +25,7 @@ docker_image:
 ffmpeg:
 - '7'
 libtorch:
-- '2.6'
+- '2.7'
 magma:
 - '2.9'
 nccl:
@@ -37,7 +37,7 @@ pin_run_as_build:
 python:
 - 3.11.* *_cpython
 pytorch:
-- '2.6'
+- '2.7'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_cuda_compiler_version12.6python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version12.6python3.12.____cpython.yaml
@@ -25,7 +25,7 @@ docker_image:
 ffmpeg:
 - '7'
 libtorch:
-- '2.6'
+- '2.7'
 magma:
 - '2.9'
 nccl:
@@ -37,7 +37,7 @@ pin_run_as_build:
 python:
 - 3.12.* *_cpython
 pytorch:
-- '2.6'
+- '2.7'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_cuda_compiler_version12.6python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version12.6python3.13.____cp313.yaml
@@ -25,7 +25,7 @@ docker_image:
 ffmpeg:
 - '7'
 libtorch:
-- '2.6'
+- '2.7'
 magma:
 - '2.9'
 nccl:
@@ -37,7 +37,7 @@ pin_run_as_build:
 python:
 - 3.13.* *_cp313
 pytorch:
-- '2.6'
+- '2.7'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_cuda_compiler_version12.6python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version12.6python3.9.____cpython.yaml
@@ -25,7 +25,7 @@ docker_image:
 ffmpeg:
 - '7'
 libtorch:
-- '2.6'
+- '2.7'
 magma:
 - '2.9'
 nccl:
@@ -37,7 +37,7 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 pytorch:
-- '2.6'
+- '2.7'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_cuda_compiler_versionNonepython3.10.____cpython.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonepython3.10.____cpython.yaml
@@ -25,7 +25,7 @@ docker_image:
 ffmpeg:
 - '7'
 libtorch:
-- '2.6'
+- '2.7'
 magma:
 - '2.9'
 nccl:
@@ -37,7 +37,7 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 pytorch:
-- '2.6'
+- '2.7'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_cuda_compiler_versionNonepython3.11.____cpython.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonepython3.11.____cpython.yaml
@@ -25,7 +25,7 @@ docker_image:
 ffmpeg:
 - '7'
 libtorch:
-- '2.6'
+- '2.7'
 magma:
 - '2.9'
 nccl:
@@ -37,7 +37,7 @@ pin_run_as_build:
 python:
 - 3.11.* *_cpython
 pytorch:
-- '2.6'
+- '2.7'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_cuda_compiler_versionNonepython3.12.____cpython.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonepython3.12.____cpython.yaml
@@ -25,7 +25,7 @@ docker_image:
 ffmpeg:
 - '7'
 libtorch:
-- '2.6'
+- '2.7'
 magma:
 - '2.9'
 nccl:
@@ -37,7 +37,7 @@ pin_run_as_build:
 python:
 - 3.12.* *_cpython
 pytorch:
-- '2.6'
+- '2.7'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_cuda_compiler_versionNonepython3.13.____cp313.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonepython3.13.____cp313.yaml
@@ -25,7 +25,7 @@ docker_image:
 ffmpeg:
 - '7'
 libtorch:
-- '2.6'
+- '2.7'
 magma:
 - '2.9'
 nccl:
@@ -37,7 +37,7 @@ pin_run_as_build:
 python:
 - 3.13.* *_cp313
 pytorch:
-- '2.6'
+- '2.7'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_cuda_compiler_versionNonepython3.9.____cpython.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonepython3.9.____cpython.yaml
@@ -25,7 +25,7 @@ docker_image:
 ffmpeg:
 - '7'
 libtorch:
-- '2.6'
+- '2.7'
 magma:
 - '2.9'
 nccl:
@@ -37,7 +37,7 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 pytorch:
-- '2.6'
+- '2.7'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_aarch64_cuda_compiler_version12.6python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version12.6python3.10.____cpython.yaml
@@ -25,7 +25,7 @@ docker_image:
 ffmpeg:
 - '7'
 libtorch:
-- '2.6'
+- '2.7'
 magma:
 - '2.9'
 nccl:
@@ -37,7 +37,7 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 pytorch:
-- '2.6'
+- '2.7'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_cuda_compiler_version12.6python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version12.6python3.11.____cpython.yaml
@@ -25,7 +25,7 @@ docker_image:
 ffmpeg:
 - '7'
 libtorch:
-- '2.6'
+- '2.7'
 magma:
 - '2.9'
 nccl:
@@ -37,7 +37,7 @@ pin_run_as_build:
 python:
 - 3.11.* *_cpython
 pytorch:
-- '2.6'
+- '2.7'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_cuda_compiler_version12.6python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version12.6python3.12.____cpython.yaml
@@ -25,7 +25,7 @@ docker_image:
 ffmpeg:
 - '7'
 libtorch:
-- '2.6'
+- '2.7'
 magma:
 - '2.9'
 nccl:
@@ -37,7 +37,7 @@ pin_run_as_build:
 python:
 - 3.12.* *_cpython
 pytorch:
-- '2.6'
+- '2.7'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_cuda_compiler_version12.6python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version12.6python3.13.____cp313.yaml
@@ -25,7 +25,7 @@ docker_image:
 ffmpeg:
 - '7'
 libtorch:
-- '2.6'
+- '2.7'
 magma:
 - '2.9'
 nccl:
@@ -37,7 +37,7 @@ pin_run_as_build:
 python:
 - 3.13.* *_cp313
 pytorch:
-- '2.6'
+- '2.7'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_cuda_compiler_version12.6python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version12.6python3.9.____cpython.yaml
@@ -25,7 +25,7 @@ docker_image:
 ffmpeg:
 - '7'
 libtorch:
-- '2.6'
+- '2.7'
 magma:
 - '2.9'
 nccl:
@@ -37,7 +37,7 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 pytorch:
-- '2.6'
+- '2.7'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_cuda_compiler_versionNonepython3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_versionNonepython3.10.____cpython.yaml
@@ -25,7 +25,7 @@ docker_image:
 ffmpeg:
 - '7'
 libtorch:
-- '2.6'
+- '2.7'
 magma:
 - '2.9'
 nccl:
@@ -37,7 +37,7 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 pytorch:
-- '2.6'
+- '2.7'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_cuda_compiler_versionNonepython3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_versionNonepython3.11.____cpython.yaml
@@ -25,7 +25,7 @@ docker_image:
 ffmpeg:
 - '7'
 libtorch:
-- '2.6'
+- '2.7'
 magma:
 - '2.9'
 nccl:
@@ -37,7 +37,7 @@ pin_run_as_build:
 python:
 - 3.11.* *_cpython
 pytorch:
-- '2.6'
+- '2.7'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_cuda_compiler_versionNonepython3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_versionNonepython3.12.____cpython.yaml
@@ -25,7 +25,7 @@ docker_image:
 ffmpeg:
 - '7'
 libtorch:
-- '2.6'
+- '2.7'
 magma:
 - '2.9'
 nccl:
@@ -37,7 +37,7 @@ pin_run_as_build:
 python:
 - 3.12.* *_cpython
 pytorch:
-- '2.6'
+- '2.7'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_cuda_compiler_versionNonepython3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_versionNonepython3.13.____cp313.yaml
@@ -25,7 +25,7 @@ docker_image:
 ffmpeg:
 - '7'
 libtorch:
-- '2.6'
+- '2.7'
 magma:
 - '2.9'
 nccl:
@@ -37,7 +37,7 @@ pin_run_as_build:
 python:
 - 3.13.* *_cp313
 pytorch:
-- '2.6'
+- '2.7'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_cuda_compiler_versionNonepython3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_versionNonepython3.9.____cpython.yaml
@@ -25,7 +25,7 @@ docker_image:
 ffmpeg:
 - '7'
 libtorch:
-- '2.6'
+- '2.7'
 magma:
 - '2.9'
 nccl:
@@ -37,7 +37,7 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 pytorch:
-- '2.6'
+- '2.7'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/osx_64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpython.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
+- '10.15'
 MACOSX_SDK_VERSION:
-- '10.13'
+- '10.15'
 c_compiler:
 - clang
 c_compiler_version:
@@ -9,7 +9,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '10.13'
+- '10.15'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpython.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 ffmpeg:
 - '7'
 libtorch:
-- '2.6'
+- '2.7'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:
@@ -35,7 +35,7 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 pytorch:
-- '2.6'
+- '2.7'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
+- '10.15'
 MACOSX_SDK_VERSION:
-- '10.13'
+- '10.15'
 c_compiler:
 - clang
 c_compiler_version:
@@ -9,7 +9,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '10.13'
+- '10.15'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 ffmpeg:
 - '7'
 libtorch:
-- '2.6'
+- '2.7'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:
@@ -35,7 +35,7 @@ pin_run_as_build:
 python:
 - 3.11.* *_cpython
 pytorch:
-- '2.6'
+- '2.7'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_python3.12.____cpython.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
+- '10.15'
 MACOSX_SDK_VERSION:
-- '10.13'
+- '10.15'
 c_compiler:
 - clang
 c_compiler_version:
@@ -9,7 +9,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '10.13'
+- '10.15'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_python3.12.____cpython.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 ffmpeg:
 - '7'
 libtorch:
-- '2.6'
+- '2.7'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:
@@ -35,7 +35,7 @@ pin_run_as_build:
 python:
 - 3.12.* *_cpython
 pytorch:
-- '2.6'
+- '2.7'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_python3.13.____cp313.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
+- '10.15'
 MACOSX_SDK_VERSION:
-- '10.13'
+- '10.15'
 c_compiler:
 - clang
 c_compiler_version:
@@ -9,7 +9,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '10.13'
+- '10.15'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_python3.13.____cp313.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 ffmpeg:
 - '7'
 libtorch:
-- '2.6'
+- '2.7'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:
@@ -35,7 +35,7 @@ pin_run_as_build:
 python:
 - 3.13.* *_cp313
 pytorch:
-- '2.6'
+- '2.7'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_python3.9.____cpython.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
+- '10.15'
 MACOSX_SDK_VERSION:
-- '10.13'
+- '10.15'
 c_compiler:
 - clang
 c_compiler_version:
@@ -9,7 +9,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '10.13'
+- '10.15'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_python3.9.____cpython.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 ffmpeg:
 - '7'
 libtorch:
-- '2.6'
+- '2.7'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:
@@ -35,7 +35,7 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 pytorch:
-- '2.6'
+- '2.7'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 ffmpeg:
 - '7'
 libtorch:
-- '2.6'
+- '2.7'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:
@@ -35,7 +35,7 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 pytorch:
-- '2.6'
+- '2.7'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 ffmpeg:
 - '7'
 libtorch:
-- '2.6'
+- '2.7'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:
@@ -35,7 +35,7 @@ pin_run_as_build:
 python:
 - 3.11.* *_cpython
 pytorch:
-- '2.6'
+- '2.7'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpython.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 ffmpeg:
 - '7'
 libtorch:
-- '2.6'
+- '2.7'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:
@@ -35,7 +35,7 @@ pin_run_as_build:
 python:
 - 3.12.* *_cpython
 pytorch:
-- '2.6'
+- '2.7'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 ffmpeg:
 - '7'
 libtorch:
-- '2.6'
+- '2.7'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:
@@ -35,7 +35,7 @@ pin_run_as_build:
 python:
 - 3.13.* *_cp313
 pytorch:
-- '2.6'
+- '2.7'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 ffmpeg:
 - '7'
 libtorch:
-- '2.6'
+- '2.7'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:
@@ -35,7 +35,7 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 pytorch:
-- '2.6'
+- '2.7'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,2 @@
+c_stdlib_version:  # [osx and x86_64]
+  - 10.15          # [osx and x86_64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,9 @@
 # Keep aligned with https://github.com/conda-forge/pytorch-cpu-feedstock/blob/71a445e6b5a73c4d0afd3ca1b235684bfcfa0bce/recipe/conda_build_config.yaml#L1C1-L2C38
 c_stdlib_version:  # [osx and x86_64]
   - 10.15          # [osx and x86_64]
+
+libtorch: 
+  - 2.7
+
+pytorch:
+  - 2.7

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,3 @@
+# Keep aligned with https://github.com/conda-forge/pytorch-cpu-feedstock/blob/71a445e6b5a73c4d0afd3ca1b235684bfcfa0bce/recipe/conda_build_config.yaml#L1C1-L2C38
 c_stdlib_version:  # [osx and x86_64]
   - 10.15          # [osx and x86_64]

--- a/recipe/fix_linking_macos.patch
+++ b/recipe/fix_linking_macos.patch
@@ -7,7 +7,7 @@ index c79f62f3..96143bcf 100644
          ${pybind_ops_library_name}
          PUBLIC
 -        "-undefined dynamic_lookup"
-+        "LINKER:-undefined;dynamic_lookup"
++        "LINKER:-undefined,dynamic_lookup"
      )
  
      # Install all libraries.

--- a/recipe/fix_linking_macos.patch
+++ b/recipe/fix_linking_macos.patch
@@ -1,0 +1,13 @@
+diff --git a/src/torchcodec/_core/CMakeLists.txt b/src/torchcodec/_core/CMakeLists.txt
+index c79f62f3..96143bcf 100644
+--- a/src/torchcodec/_core/CMakeLists.txt
++++ b/src/torchcodec/_core/CMakeLists.txt
+@@ -148,7 +148,7 @@ function(make_torchcodec_libraries
+     target_link_options(
+         ${pybind_ops_library_name}
+         PUBLIC
+-        "-undefined dynamic_lookup"
++        "LINKER:-undefined;dynamic_lookup"
+     )
+ 
+     # Install all libraries.

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -15,6 +15,7 @@ source:
     sha256: f535f184f7abe2460d759df7157fa99b40a12ee5d6ffc2eb9155956b7cc209d8
     patches:
       - remove_werror.patch
+      - fix_linking_macos.patch
 
 build:
   number: ${{ build_number }}

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -60,7 +60,7 @@ outputs:
         - if: cuda_compiler_version != "None"
           then:
             - ${{ compiler('cuda') }}
-        - cmake 3.*
+        - cmake
         - pkg-config
         - make
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -124,7 +124,6 @@ outputs:
             - pytest
             - numpy
             - pillow
-            - torchvision
         script:
           - pytest test
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -78,6 +78,7 @@ outputs:
         - libtorch * [build=${{ torch_proc_type }}*]
         - pytorch
         - pytorch * [build=${{ torch_proc_type }}*]
+        - pybind11
 
         - if: cuda_compiler_version != "None"
           then:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,8 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
 
 context:
-  version: "0.2.1"
-  build_number: 3
+  version: "0.3.0"
+  build_number: 0
   torch_proc_type: ${{ "cuda" ~ cuda_compiler_version | version_to_buildstring if cuda_compiler_version != "None" else "cpu" }}
   string_prefix: ${{ cuda_build_string if cuda == "true" else "cpu_" }}
 
@@ -12,7 +12,9 @@ recipe:
 
 source:
   - url: https://github.com/pytorch/torchcodec/archive/refs/tags/v${{ version }}.tar.gz
-    sha256: b142ef4fef1e9ddb6dde70dda6ac4d12a02a010065230468eadbf37478621927
+    sha256: f535f184f7abe2460d759df7157fa99b40a12ee5d6ffc2eb9155956b7cc209d8
+    patches:
+      - remove_werror.patch
 
 build:
   number: ${{ build_number }}
@@ -61,7 +63,7 @@ outputs:
         - cmake
         - pkg-config
         - make
-    
+
       host:
         - python
         - pip
@@ -75,7 +77,7 @@ outputs:
         - libtorch * [build=${{ torch_proc_type }}*]
         - pytorch
         - pytorch * [build=${{ torch_proc_type }}*]
-    
+
         - if: cuda_compiler_version != "None"
           then:
             # These are dev packages (headers etc.) for transitive dependencies of libtorch
@@ -98,8 +100,7 @@ outputs:
       run:
         - python
         - pytorch * [build=${{ torch_proc_type }}*]
-    
-    
+
     tests:
       - python:
           imports:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -60,7 +60,7 @@ outputs:
         - if: cuda_compiler_version != "None"
           then:
             - ${{ compiler('cuda') }}
-        - cmake
+        - cmake 3.*
         - pkg-config
         - make
 

--- a/recipe/remove_werror.patch
+++ b/recipe/remove_werror.patch
@@ -1,0 +1,13 @@
+diff --git a/src/torchcodec/_core/CMakeLists.txt b/src/torchcodec/_core/CMakeLists.txt
+index c79f62f3..928d4fb8 100644
+--- a/src/torchcodec/_core/CMakeLists.txt
++++ b/src/torchcodec/_core/CMakeLists.txt
+@@ -8,7 +8,7 @@ find_package(pybind11 REQUIRED)
+ find_package(Torch REQUIRED)
+ find_package(Python3 ${PYTHON_VERSION} EXACT COMPONENTS Development)
+ 
+-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Werror ${TORCH_CXX_FLAGS}")
++set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic ${TORCH_CXX_FLAGS}")
+ 
+ function(make_torchcodec_sublibrary
+     library_name


### PR DESCRIPTION
At the PyPI packages level, torchcodec 0.3.0 requires torch 2.7.0 (currently not available in conda-forge, see https://github.com/conda-forge/pytorch-cpu-feedstock/pull/383). However, this dependency is just due to ABI (see https://github.com/pytorch/torchcodec/issues/655#issuecomment-2830040193), so here in conda-forge it should be sufficient to just build 0.3.0 against pytorch 2.6.0 and if the test pass we should be good to go.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
