### PR TITLE
Re-enable linux-aarch64 builds

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@
 
 context:
   version: "0.2.1"
-  build_number: 3
+  build_number: 4
   torch_proc_type: ${{ "cuda" ~ cuda_compiler_version | version_to_buildstring if cuda_compiler_version != "None" else "cpu" }}
   string_prefix: ${{ cuda_build_string if cuda == "true" else "cpu_" }}
 
@@ -13,6 +13,8 @@ recipe:
 source:
   - url: https://github.com/pytorch/torchcodec/archive/refs/tags/v${{ version }}.tar.gz
     sha256: b142ef4fef1e9ddb6dde70dda6ac4d12a02a010065230468eadbf37478621927
+    patches:
+      - use_strict_threshold_only_for_linux_x86_64.patch
 
 build:
   number: ${{ build_number }}
@@ -21,10 +23,7 @@ build:
     - cuda_compiler_version == "11.8"
     # Upstream does not support Windows at the moment https://github.com/pytorch/torchcodec/issues/522
     - win
-    # Compilation with linux-aarch64 works, but the tests are not passing, see https://github.com/pytorch/torchcodec/issues/569
-    - linux and aarch64
   string: ${{ torch_proc_type }}_py${{ python | version_to_buildstring }}_h${{ hash }}_${{ build_number }}
-
 
 outputs:
   - package:

--- a/recipe/use_strict_threshold_only_for_linux_x86_64.patch
+++ b/recipe/use_strict_threshold_only_for_linux_x86_64.patch
@@ -1,0 +1,21 @@
+diff --git a/test/utils.py b/test/utils.py
+index 9186e6608..f0f9130da 100644
+--- a/test/utils.py
++++ b/test/utils.py
+@@ -2,6 +2,7 @@
+ import json
+ import os
+ import pathlib
++import platform
+ import sys
+ 
+ from dataclasses import dataclass
+@@ -36,7 +37,7 @@ def get_ffmpeg_major_version():
+ # not guarantee bit-for-bit equality across systems and architectures, so we
+ # also cannot. We currently use Linux on x86_64 as our reference system.
+ def assert_frames_equal(*args, **kwargs):
+-    if sys.platform == "linux":
++    if sys.platform == "linux" and platform.machine() == "x86_64":
+         if args[0].device.type == "cuda":
+             atol = 2
+             if get_ffmpeg_major_version() == 4:


### PR DESCRIPTION
Fix #10 .

See https://github.com/pytorch/torchcodec/issues/569#issuecomment-2834723326 for more details.

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
